### PR TITLE
- New patch so you can hold the mouse button to scan belt checkout pr…

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,11 @@
 ## Changelog
-
-### 0.8.2.0
+### 0.8.3.0
+	- Requested by Aretha Cairn: You can now hold the mouse button to scan items in the checkout belt.
+		It should make easier to play cashier for long periods of time.
+	- Requested by Aretha Cairn: New setting to expand the clickable area of the product order button in the blackboard, so it can be clicked (almost) anywhere in its product square.
+	- Added support for "Custom Products" mod to avoid an exception when loading the game.
+	- Removed debug log from the pricing gun fix that I forgot to remove. Oh no.
+#### 0.8.2.0
 	- Pricing gun fixed so doubling the price no longer makes customers complain.
 		This one needs a bit of an explanation on why I consider it a bug:
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,37 @@
 # SuperQoLity - AI, performance, and QoL changes for Supermarket Together
 
-## Features:
 
+## Features 
 - NPC job coordination. Employees wont go for the same jobs anymore.
 - Shelf/storage highlighting functionality, inherited from BetterSMT, with customizable colors. BetterSMT is not needed for this.
 - Configurable employee movement speed while the store is closed. Faster and less laggy than the star perk.
 - Configurable, faster item transfer to/from shelves, for players and/or employees.
 - Many small and not so small performance optimisations to employees (more to come).
+- You can hold the mouse button to keep scanning items in the checkout belt.
 - Implemented an employee job scheduler that lets you choose their workload performance.
 - Configurable storage priority for employees (labeled/unlabeled/any)
 - Configurable employee wait time after finishing a job step.
-- Pricing gun fixed so doubling the price no longer makes customers complain (Check 0.8.2.0 changelog to see why I see this as a bug)
+- Pricing gun fixed so doubling the price no longer makes customers complain (Check 0.8.2 changelog on why I see this as a bug)
+- In the blackboard, you can click anywhere on a product to add it to the shopping list, instead of just the button.
 - Storage employees prioritise the closest box on the floor, instead of random one.
-- And tons of bugs I missed.
+- And tons of my own bugs that I missed.
+
+#### All features are optional
+
+#### - Multiplayer
 
 This mod is multiplayer ready. If a setting has any multiplayer requirements (only hosts, only clients, etc), its description will tell you so.
+
+By design, and to promote fair play, the host has control over some of the allowed features. If the host doesnt have the mod, or it has the feature disabled in settings, the client wont be able to use it.
 <br />
 
-#### NOTE ABOUT THE SETTINGS
+#### - About the settings
 
-All settings in this mod have base game values by default. You need to edit the config to enable most features.<br />
+All settings have base game values by default. You need to change them to enable (most, see below*) features.<br />
 If you dont have an in-game config manager, I recommend using the BepInEx5 version of BepInEx.ConfigurationManager, as it lets you change settings in-game:<br />
 https://github.com/BepInEx/BepInEx.ConfigurationManager/releases
 
-By design and to promote fair play, the host has control over some of the allowed features. If the host doesnt have the mod, or it has the feature disabled, the client wont be able to use it.
+*<sub>Some features do not have an individual setting, and instead depend on its module being enabled. Since modules themselves are enabled by default, those will be active once you start the game. Examples of this are NPC coordination and Highlighting)</sub>
 
-### Known bugs:
-None.
-				
-	The unknown bugs are the ones that keep me up at night.
+#### - Known bugs:
+None, but the unknown are the ones that keep me up at night.

--- a/SMT_QoLity/MyPlugin.info
+++ b/SMT_QoLity/MyPlugin.info
@@ -6,7 +6,7 @@
     <RootNamespace>$(AssemblyName)</RootNamespace>
     <PackageId>es.damntry.SuperQoLity</PackageId>
     <Product>$(PackageId)</Product>
-    <Version>0.8.2.0</Version>
+    <Version>0.8.3.0</Version>
     <Description>Bepinex plugin for Supermarket Together adding extra QoL features</Description>
     <Authors>Damntry</Authors>
     <Company>None</Company>

--- a/SMT_QoLity/Plugin.cs
+++ b/SMT_QoLity/Plugin.cs
@@ -10,6 +10,7 @@ using Damntry.UtilsUnity.Components;
 using StarterAssets;
 using SuperQoLity.SuperMarket.ModUtils;
 using SuperQoLity.SuperMarket.ModUtils.ExternalMods;
+using SuperQoLity.SuperMarket.PatchClassHelpers.Components;
 using SuperQoLity.SuperMarket.PatchClassHelpers.Employees.JobScheduler;
 using SuperQoLity.SuperMarket.PatchClassHelpers.Employees.RestockMatch;
 
@@ -18,6 +19,10 @@ namespace SuperQoLity {
 
 	//TODO 1 - Find things Im loading on WorldStart and try to move them earlier if possible.
 	//	There is noticeable lag when starting compared to base game, specially on big stores.
+
+	//TODO 2 - Make a method that when debug is enabled and a certain hotkey is pressed, it gathers
+	//	info about installed mods, the current LogOutput and what not, and copies it into the clipboard
+	//	to help users make error reporting easier.
 
 	//Soft dependency so we load after ika.smtanticheat and BetterSMT if they exist.
 	[BepInDependency(ModInfoSMTAntiCheat.GUID, BepInDependency.DependencyFlags.SoftDependency)]

--- a/SMT_QoLity/SuperMarket/ModUtils/ModConfig.cs
+++ b/SMT_QoLity/SuperMarket/ModUtils/ModConfig.cs
@@ -50,7 +50,9 @@ namespace SuperQoLity.SuperMarket.ModUtils {
 		public ConfigEntry<Color> StorageSlotHighlightColor { get; private set; }
 
 		public ConfigEntry<bool> EnableMiscPatches { get; private set; }
+		public ConfigEntry<bool> EnableCheckoutAutoClicker { get; private set; }
 		public ConfigEntry<bool> EnablePriceGunFix { get; private set; }
+		public ConfigEntry<bool> EnableExpandedProdOrderClickArea { get; private set; }
 
 		public ConfigEntry<bool> EnableModNotifications { get; private set; }
 		public ConfigEntry<bool> EnableWelcomeMessages { get; private set; }
@@ -348,6 +350,16 @@ namespace SuperQoLity.SuperMarket.ModUtils {
 				description: string.Format(moduleGenericEnablerDescription, miscModuleText)
 			);
 
+			EnableCheckoutAutoClicker = configManagerControl.AddConfig(
+				sectionName: miscModuleText,
+				key: "Hold click to scan checkout products",
+				defaultValue: false,
+				description: "Instead of having to keep pressing Main Action (Left Click by default) to scan each product " +
+				"on the cash register belt, you can hold it to continuously scan as you mouse over products.",
+				patchInstanceDependency: Container<CheckoutAutoClickScanner>.Instance,
+				modInstallSide: MultiplayerModInstallSide.Any
+			);
+
 			EnablePriceGunFix = configManagerControl.AddConfig(
 				sectionName: miscModuleText,
 				key: "Enable pricing gun double price fix",
@@ -356,6 +368,16 @@ namespace SuperQoLity.SuperMarket.ModUtils {
 				"See the 0.8.2.0 changelog for a explanation on why I consider this a bug.",
 				patchInstanceDependency: Container<PricingGunFixPatch>.Instance,
 				modInstallSide: MultiplayerModInstallSide.HostSideOnly
+			);
+
+			EnableExpandedProdOrderClickArea = configManagerControl.AddConfig(
+				sectionName: miscModuleText,
+				key: "Increased clickable area in product order",
+				defaultValue: false,
+				description: "When at the Manager Blackboard, you can click anywhere in the product panel " +
+				"to add it to the shopping list, instead of just the \"+\" button.",
+				patchInstanceDependency: Container<ExpandProductOrderClickArea>.Instance,
+				modInstallSide: MultiplayerModInstallSide.Any
 			);
 		}
 		private void InitializeNotificationModule() {

--- a/SMT_QoLity/SuperMarket/ModUtils/SMTGameObjectManager.cs
+++ b/SMT_QoLity/SuperMarket/ModUtils/SMTGameObjectManager.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.ComponentModel;
+using Damntry.Utils.ExtensionMethods;
+using Damntry.Utils.Logging;
+using Damntry.UtilsUnity.ExtensionMethods;
+using StarterAssets;
+using UnityEngine;
+using Component = UnityEngine.Component;
+
+namespace SuperQoLity.SuperMarket.ModUtils {
+
+	public enum TargetObject {
+		[Description("MasterOBJ/MasterCanvas")]
+		UI_MasterCanvas,
+		[Description("LocalGamePlayer")]
+		LocalGamePlayer,
+		[Description("GameDataManager")]
+		GameDataManager,
+	}
+
+	//TODO 5 - Ideally this could be a Globals Bepinex class where all data and the target objects are 
+	//		added on initialization, but then I would lose the compile time enum names.
+	public static class SMTGameObjectManager {
+
+		public const string RootGameObject = "MasterOBJ";
+
+		private static readonly string superQolityPrefix = "SuperQoL_";
+
+		public static GameObject CreateSuperQoLGameObject(string name, TargetObject parentTarget, bool active = true) {
+			if (GetGameObjectFrom(parentTarget, out GameObject parentObject)) {
+				return CreateSuperQoLGameObject(name, parentObject, active);
+			}
+
+			return null;
+		}
+
+		public static GameObject CreateSuperQoLGameObject(string name, GameObject parentObject, bool active = true) {
+			if (parentObject == null) {
+				TimeLogger.Logger.LogTimeError($"The parameter {nameof(parentObject)} cannot be null.",
+					LogCategories.Other);
+				return null;
+			}
+			GameObject gameObj = new(superQolityPrefix + name);
+			gameObj.SetActive(active);
+			gameObj.transform.SetParent(parentObject.transform);
+
+			return gameObj;
+		}
+
+		public static T AddComponentTo<T>(TargetObject parentTarget)
+				where T : Component {
+
+			if (GetGameObjectFrom(parentTarget, out GameObject parentObject)) {
+				return parentObject.AddComponent<T>();
+			}
+
+			return null;
+		}
+
+		public static bool GetGameObjectFrom(TargetObject targetObject, out GameObject gameObject) {
+			//Try fast method using children component instance as a reference
+			gameObject = GetComponentForTargetObject(targetObject).GameObject();
+
+			//If the component is not alive, search for the GameObject.
+			gameObject ??= GameObject.Find(targetObject.GetDescription());
+
+			if (gameObject == null) {
+				TimeLogger.Logger.LogTimeError($"The GameObject for target " +
+					$"\"{targetObject}\" ({targetObject.GetDescription()}) could not be retrieved. Maybe you need " +
+					$"to do this it at a later point?", LogCategories.Other);
+
+				TimeLogger.Logger.LogTimeError($"On the other hand, the GameObject.Find is null? " +
+					$"{GameObject.Find(targetObject.GetDescription()) == null}", LogCategories.TempTest);
+			}
+
+			return gameObject != null;
+		}
+
+		private static Component GetComponentForTargetObject(TargetObject targetObject) =>
+			targetObject switch {
+				TargetObject.UI_MasterCanvas => SMTComponentInstances.GameCanvasInstance(),
+				TargetObject.LocalGamePlayer => SMTComponentInstances.FirstPersonControllerInstance(),
+				TargetObject.GameDataManager => SMTComponentInstances.GameDataManagerInstance(),
+				_ => throw new NotImplementedException($"{targetObject} value is not implemented.")
+			};
+
+	}
+
+
+	public struct SMTComponentInstances {
+		public static GameCanvas GameCanvasInstance() => GameCanvas.Instance;
+		public static FirstPersonController FirstPersonControllerInstance() => FirstPersonController.Instance;
+		public static PlayerNetwork PlayerNetworkInstance() => FirstPersonControllerInstance()?.GetComponent<PlayerNetwork>();
+		public static GameData GameDataManagerInstance() => GameData.Instance;
+	}
+}

--- a/SMT_QoLity/SuperMarket/PatchClassHelpers/Components/FrequencyMult_Display.cs
+++ b/SMT_QoLity/SuperMarket/PatchClassHelpers/Components/FrequencyMult_Display.cs
@@ -25,9 +25,7 @@ namespace SuperQoLity.SuperMarket.PatchClassHelpers.Components {
 		private bool allowDisplay;
 		
 		private void Awake() {
-			freqMultDisplay = new GameObject("JobFreqMult_Display");
-			freqMultDisplay.transform.SetParent(masterCanvas.transform);
-			freqMultDisplay.SetActive(false);
+			freqMultDisplay = SMTGameObjectManager.CreateSuperQoLGameObject("JobWorkload_Display", TargetObject.UI_MasterCanvas, false);
 
 			SetupUI();
 
@@ -43,8 +41,7 @@ namespace SuperQoLity.SuperMarket.PatchClassHelpers.Components {
 		}
 
 		public static void Initialize() {
-			masterCanvas = GameObject.Find("MasterOBJ/MasterCanvas");
-			masterCanvas.AddComponent<FrequencyMult_Display>();
+			SMTGameObjectManager.AddComponentTo<FrequencyMult_Display>(TargetObject.UI_MasterCanvas);
 		}
 
 		private void SetupUI() {

--- a/SMT_QoLity/SuperMarket/PatchClassHelpers/Components/InputBehaviour.cs
+++ b/SMT_QoLity/SuperMarket/PatchClassHelpers/Components/InputBehaviour.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using Damntry.Utils.Logging;
+using Rewired;
+using SuperQoLity.SuperMarket.ModUtils;
+using UnityEngine;
+
+namespace SuperQoLity.SuperMarket.PatchClassHelpers.Components {
+
+	public class InputBehaviour : MonoBehaviour {
+
+		private static InputBehaviour instance;
+
+		private Player MainPlayerControls;
+
+		private static bool isActive;
+
+		private static GameWorldEvent behaviourWorldEvent = GameWorldEvent.FPControllerStarted;
+
+
+		public delegate void InputAction(float currentTime, Player MainPlayerControls);
+
+		private static Dictionary<Type, (GameWorldEvent worldEventToStartAt, InputAction inputAction)> subscriptedReferences;
+
+
+
+		public static void RegisterClickAction<T>(InputAction inputAction, GameWorldEvent worldEventToStartAt)
+				where T : class {
+			
+			ActivateBehaviour();
+
+			subscriptedReferences.Add(typeof(T), (worldEventToStartAt, inputAction));
+		}
+
+		public static void UnregisterClickAction<T>()
+				where T : class {
+
+			subscriptedReferences.Remove(typeof(T));
+
+			if (subscriptedReferences.Count == 0) {
+				DeactivateBehaviour();
+			}
+		}
+
+		private static void ActivateBehaviour() {
+			if (isActive) {
+				return;
+			}
+
+			subscriptedReferences = new();
+
+			if (instance == null || !instance.didAwake) {
+				WorldState.SubscribeToWorldStateEvent(behaviourWorldEvent, AddInputBehaviourComponent);
+				Action addComponentEvent = WorldState.GetSubscribersForWorldState(behaviourWorldEvent);
+
+				if (WorldState.IsGameWorldAtOrAfter(behaviourWorldEvent)) {
+					AddInputBehaviourComponent();
+				}
+			}
+
+			isActive = true;
+			if (instance != null) {
+				instance.enabled = true;
+			}
+		}
+
+		private static void AddInputBehaviourComponent() {
+			if (SMTGameObjectManager.AddComponentTo<InputBehaviour>(TargetObject.LocalGamePlayer) == null) {
+				TimeLogger.Logger.LogTimeError("The click behaviour component could not be added " +
+					"and all its related logic wont work.", LogCategories.KeyMouse);
+			}
+		}
+
+		private static void DeactivateBehaviour() {
+			if (!isActive) {
+				return;
+			}
+
+			subscriptedReferences = null;
+
+			isActive = false;
+			instance.enabled = false;
+		}
+
+
+		public void Awake() {
+			instance = this;
+
+			KeyActions.Initialize();
+
+			PlayerNetwork pNetwork = SMTComponentInstances.PlayerNetworkInstance();
+			MainPlayerControls = pNetwork.MainPlayer;
+		}
+
+		public void Update() {
+			float currentTime = Time.time;
+
+			//Call registered methods.
+			foreach (var reference in subscriptedReferences) {
+				if (WorldState.IsGameWorldAtOrAfter(reference.Value.worldEventToStartAt)) {
+					reference.Value.inputAction(currentTime, MainPlayerControls);
+				}
+			}
+		}
+
+	}
+
+	public struct KeyActions {
+
+		public static void Initialize() {
+			MainActionId = ReInput.mapping.GetActionId(ActionNames.MainAction);
+			SecondaryActionId = ReInput.mapping.GetActionId(ActionNames.SecondaryAction);
+
+			if (MainActionId < 0 && SecondaryActionId < 0) {
+				throw new InvalidOperationException("None of the supported keys could " +
+					$"be retrieved. {MyPluginInfo.PLUGIN_NAME} click behaviours wont work.");
+			}
+			if (MainActionId < 0) {
+				TimeLogger.Logger.LogTimeError($"An action could not be found with name " +
+					$"\"{ActionNames.MainAction}\"", LogCategories.KeyMouse);
+			}
+			if (SecondaryActionId < 0) {
+				TimeLogger.Logger.LogTimeError($"An action could not be found with name " +
+					$"\"{ActionNames.MainAction}\"", LogCategories.KeyMouse);
+			}
+		}
+
+		/// <summary>Left click by default</summary>
+		public static int MainActionId { get; private set; }
+		/// <summary>Right click by default</summary>
+		public static int SecondaryActionId { get; private set; }
+
+		private readonly struct ActionNames {
+			public readonly static string MainAction = "Main Action";
+			public readonly static string SecondaryAction = "Secondary Action";
+		}
+
+	}
+
+}

--- a/SMT_QoLity/SuperMarket/PatchClassHelpers/Networking/SyncVarBehaviours/ItemTransferNetwork.cs
+++ b/SMT_QoLity/SuperMarket/PatchClassHelpers/Networking/SyncVarBehaviours/ItemTransferNetwork.cs
@@ -4,6 +4,7 @@ using SuperQoLity.SuperMarket.ModUtils;
 using SuperQoLity.SuperMarket.Patches.EmployeeModule;
 using SuperQoLity.SuperMarket.Patches.TransferItemsModule;
 using Damntry.UtilsBepInEx.MirrorNetwork.SyncVar;
+using Damntry.Utils.Logging;
 
 namespace SuperQoLity.SuperMarket.PatchClassHelpers.Networking.SyncVarBehaviours {
 
@@ -21,6 +22,26 @@ namespace SuperQoLity.SuperMarket.PatchClassHelpers.Networking.SyncVarBehaviours
 			ItemTransferQuantitySync = new(EmployeeJobAIPatch.NumTransferItemsBase, ModConfig.Instance.NumTransferProducts);
 		}
 
+		//TODO 0 - Network - RPC TEST
+		/*
+		protected override void OnSyncVarsNetworkReady() {
+			base.OnSyncVarsNetworkReady();
+
+			LOG.TEMPWARNING("OnSyncVarsNetworkReady: Going to call doSomethingRPC");
+
+			doSomethingRPC(4);
+		}
+
+		
+		[RPC_CallOnClient(typeof(ItemTransferNetwork), nameof(doSomething))]
+		private void doSomethingRPC(int paramTest) {
+			LOG.TEMPWARNING($"Original doSomethingRPC method called with param {paramTest}");
+		}
+
+		private void doSomething(int paramTest) {
+			LOG.TEMPWARNING($"Target doSomething method called with param {paramTest}");
+		}
+		*/
 	}
 
 }

--- a/SMT_QoLity/SuperMarket/Patches/EmployeeModule/EmployeeJobAIPatch.cs
+++ b/SMT_QoLity/SuperMarket/Patches/EmployeeModule/EmployeeJobAIPatch.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using Damntry.Utils.Logging;
 using Damntry.UtilsBepInEx.HarmonyPatching.AutoPatching.BaseClasses.Inheritable;
 using Mirror;
@@ -271,6 +272,9 @@ namespace SuperQoLity.SuperMarket.Patches.EmployeeModule {
 				if (employee.equippedItem > 0) {
 					__instance.DropBoxOnGround(employee);
 					__instance.UnequipBox(employee);
+				}
+				if (state != 0) {
+					employee.state = 0;
 				}
 				return true;
 			}

--- a/SMT_QoLity/SuperMarket/Patches/GameWorldEventsPatch.cs
+++ b/SMT_QoLity/SuperMarket/Patches/GameWorldEventsPatch.cs
@@ -5,6 +5,7 @@ using Damntry.UtilsBepInEx.HarmonyPatching.AutoPatching;
 using Damntry.UtilsBepInEx.HarmonyPatching.AutoPatching.BaseClasses.Inheritable;
 using HarmonyLib;
 using Mirror;
+using StarterAssets;
 using UnityEngine;
 
 namespace SuperQoLity.SuperMarket.Patches {
@@ -110,13 +111,21 @@ namespace SuperQoLity.SuperMarket.Patches {
 			}
 		}
 
+		private class FirstPersonControllerStart {
+
+			[HarmonyPatch(typeof(FirstPersonController), "Start")]
+			[HarmonyPostfix]
+			public static void OnClientDisconnectPatch(GameCanvas __instance) {
+				WorldState.SetGameWorldState(GameWorldEvent.FPControllerStarted);
+			}
+
+		}
 
 		private class DetectQuitToMainMenu {
 
 			[HarmonyPatch(typeof(CustomNetworkManager), nameof(CustomNetworkManager.OnClientDisconnect))]
 			[HarmonyPostfix]
 			public static void OnClientDisconnectPatch(GameCanvas __instance) {
-				TimeLogger.Logger.LogTimeDebug("Quitting to main menu.", LogCategories.Other);
 				WorldState.CurrenOnlineMode = GameOnlineMode.None;
 				WorldState.SetGameWorldState(GameWorldEvent.QuitOrMenu);
 			}

--- a/SMT_QoLity/SuperMarket/Patches/Misc/CheckoutAutoClickScanner.cs
+++ b/SMT_QoLity/SuperMarket/Patches/Misc/CheckoutAutoClickScanner.cs
@@ -1,0 +1,252 @@
+﻿using System.Collections;
+using System.Linq;
+using Damntry.Utils.Collections;
+using Damntry.Utils.Logging;
+using Damntry.UtilsBepInEx.HarmonyPatching.AutoPatching.BaseClasses.Inheritable;
+using HarmonyLib;
+using Rewired;
+using StarterAssets;
+using SuperQoLity.SuperMarket.ModUtils;
+using SuperQoLity.SuperMarket.PatchClassHelpers.Components;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace SuperQoLity.SuperMarket.Patches.Misc {
+
+	
+	public class CheckoutAutoClickScanner : FullyAutoPatchedInstance {
+
+		public override bool IsAutoPatchEnabled => ModConfig.Instance.EnableMiscPatches.Value;
+
+		public override string ErrorMessageOnAutoPatchFail { get; protected set; } = 
+			$"{MyPluginInfo.PLUGIN_NAME} - Increased clickable area in product order patch failed. Disabled.";
+
+
+		private LayerMask interactableMask = -1;
+
+		private FixedCapacityUniqueQueue<ProductCheckoutSpawn> checkoutItemQueue;
+
+		private static readonly int MaxItemsQueue = 2;
+
+		private float nextCheckoutProductPickTime;
+
+		private float nextCheckoutProductQueueTime;
+
+		private float DequeueTimeLimit;
+
+		private static readonly float CheckoutProductPickInterval = 0.175f;
+
+		private static readonly float CheckoutProductQueueInterval = 0.025f;
+
+		private static readonly float NoCashierPermissionDelay = 0.5f;
+
+		//In practice, with a 0.175 pick interval and a 0.20 dequeue time, its like the
+		//	queue only allowed 1 item. But the plan is to eventually have a slower click
+		//	time, that you can speed up through progression through perks or usage or something.
+		private static readonly float AllowedDequeueTimeSinceLastRaycast = 0.20f;
+
+		//Once I add different kinds of delays, this value will be assigned with the lowest one.
+		private static readonly float NoHitDelay = CheckoutProductQueueInterval;
+
+		private bool wasButtonDown;
+
+
+		public override void OnPatchFinishedVirtual(bool IsPatchActive) {
+			if (IsPatchActive) {
+				checkoutItemQueue = new(MaxItemsQueue, true);
+
+				ModConfig.Instance.EnableCheckoutAutoClicker.SettingChanged += (_, _) => ManageState();
+
+				ManageState();
+			}
+		}
+
+
+		/// <summary>
+		/// Makes the value of ProductCheckoutSpawn.isFinished false by default.
+		/// See comments in <see cref="CheckoutProductAimed"/> on why I do this.
+		/// </summary>
+		[HarmonyPatch(typeof(ProductCheckoutSpawn), "CreateProductObject")]
+		[HarmonyPostfix]
+		public static IEnumerator CreateProductObject(IEnumerator result, ProductCheckoutSpawn __instance) {
+			while (result.MoveNext()) {
+				yield return result.Current;
+			}
+
+			__instance.isFinished = false;
+		}
+
+
+		private void ManageState() {
+			if (ModConfig.Instance.EnableCheckoutAutoClicker.Value) {
+				WorldState.OnFPControllerStarted += InitState;
+
+				InputBehaviour.RegisterClickAction<CheckoutAutoClickScanner>(
+					inputAction: ProcessCheckoutProductPickup,
+					//We depend of FirstPersonController -> PlayerNetwork component.
+					worldEventToStartAt: GameWorldEvent.FPControllerStarted
+				);
+			} else {
+				WorldState.OnFPControllerStarted -= InitState;
+
+				InputBehaviour.UnregisterClickAction<CheckoutAutoClickScanner>();
+			}
+
+			if (WorldState.IsGameWorldAtOrAfter(GameWorldEvent.FPControllerStarted)) {
+				InitState();
+			}
+		}
+
+		private void InitState() {
+			SetVanillaCheckoutScanState(!ModConfig.Instance.EnableCheckoutAutoClicker.Value);
+
+			if (interactableMask < 0) {
+				interactableMask = SMTComponentInstances.PlayerNetworkInstance().interactableMask;
+			}
+		}
+
+		/*TODO 0 - Not sure I should try the full save thingy. I though of some bad case:
+
+			I load everything as it is in the extra save file, FSM states, etc, EVERYTHING.
+			A mod changes the prefab of something, but obviously not expecting that such prefab 
+				could have possibly have been instanced already due to the way the game works normally.
+			Now that mod is fucked, who knows what happens.
+			
+			I would need to offer some framework to mods so they can make it compatible with my saves.
+			And I would need to change out stuff since I DO the prefab modifying thing.
+
+		*/
+
+		/// <summary>
+		/// Enables or disables the vanilla game implementation to scan checkout
+		/// products, of having to click products one by one.
+		/// </summary>
+		private static void SetVanillaCheckoutScanState(bool enable) {
+			//Change the main prefab from which products are instantiated.
+			ChangeVanillaClickEnabled(NPC_Manager.Instance.productCheckoutPrefab, enable);
+
+			//If there are products already spawned, must update each one "enabled" state.
+			ChangeClickAllSpawnProductsInScene(enable);
+		}
+
+		private static void ChangeClickAllSpawnProductsInScene(bool enable) {
+			if (!WorldState.IsGameWorldAtOrAfter(GameWorldEvent.LoadingWorld)){
+				return;
+			}
+
+			var spawnObjs = SceneManager.GetActiveScene()
+				.GetRootGameObjects()
+				.Where(g => g.TryGetComponent<ProductCheckoutSpawn>(out _));
+
+			foreach (GameObject spawnObj in spawnObjs) {
+				ChangeVanillaClickEnabled(spawnObj, enable);
+			}
+		}
+
+		private static void ChangeVanillaClickEnabled(GameObject spawnObject, bool enable) {
+			spawnObject
+				.GetComponent<ProductCheckoutSpawn>()
+				.GetComponents<PlayMakerFSM>()
+				.FirstOrDefault(fsm => fsm.FsmName == "Behaviour")
+				.enabled = enable;
+		}
+
+		public void ProcessCheckoutProductPickup(float currentTime, Player mainPlayerControl) {
+			int scanProdAction = KeyActions.MainActionId;
+
+			if (wasButtonDown && mainPlayerControl.GetButtonUp(scanProdAction)) {
+				wasButtonDown = false;
+				checkoutItemQueue.Clear();
+
+				//Clear times to allow players to spam click if they still want.
+				nextCheckoutProductQueueTime = 0;
+				nextCheckoutProductPickTime = 0;
+			}
+
+			if (nextCheckoutProductQueueTime > currentTime) {
+				//Too early to click or queue
+				return;
+			}
+
+			if (mainPlayerControl.GetButton(scanProdAction)) {
+				wasButtonDown = true;
+				//Default delay for performance. It may be set to a different value below.
+				nextCheckoutProductQueueTime = currentTime + NoHitDelay;
+
+				if (!FirstPersonController.Instance.GetComponent<PlayerPermissions>().RequestCP()) {
+					//Player does not have cashier permission.
+					nextCheckoutProductQueueTime = currentTime + NoCashierPermissionDelay;
+					return;
+				}
+
+				if (Physics.Raycast(Camera.main.transform.position,
+						Camera.main.transform.forward, out RaycastHit raycastHit, 4f, interactableMask) &&
+						raycastHit.transform.TryGetComponent(out ProductCheckoutSpawn productBelt)) {
+
+					DequeueTimeLimit = currentTime + AllowedDequeueTimeSinceLastRaycast;
+
+					CheckoutProductAimed(currentTime, productBelt);
+				} else if (nextCheckoutProductPickTime < currentTime && checkoutItemQueue.Count > 0) {
+					//Dont want to have items being scanned seemingly magically after last real raycast.
+					//	Instead of artifically limiting the queue to solve this, check if its been 
+					//	long enough from last successful product raycast.
+					if (DequeueTimeLimit >= currentTime) {
+						PerformCheckoutProductClick(checkoutItemQueue.Dequeue(), currentTime);
+					} else {
+						checkoutItemQueue.Clear();
+					}
+				}
+			}
+
+			//Debug.TestAndDebugPatch.CheckoutProductFiller.PlaceProductOnBelt();
+		}
+
+		private void CheckoutProductAimed(float currentTime, ProductCheckoutSpawn productBelt) {
+			if (nextCheckoutProductPickTime < currentTime) {
+				//In time to perform a click;
+				PerformCheckoutProductClick(productBelt, currentTime);
+				//Since we prioritize current raycasts vs queued ones, products sitting in the queue that
+				//	where moused over earlier, could now start getting scanned if no new raycast 
+				//	is found, which looks out of order and unnatural. To avoid this we clear the queue.
+				checkoutItemQueue.Clear();
+			} else {
+				//Queue the object to be clicked. This is an extra smoothing functionality so
+				//	we can keep a steady click interval, while still letting mouse hovered
+				//	products enter a short queue to be latter clicked if no product is currently raycasted.
+				//	This lets you fluidly mouse over products to pick them up, instead of having
+				//	to jerk the mouse over every item and wait for the click cooldown to end.
+				if (productBelt.isFinished) {
+					//The check interval is short enough that it can queue an object that was already clicked and 
+					//	scheduled to be destroyed, which eventually makes it try to process a GameObject with netid 0.
+					//	To avoid this I ll just use ProductCheckoutSpawn.isFinished to flag this product as "processed",
+					//	since isFinished is now unused after I disabled the FSM that accessed it.
+					//	I ll probably regret this decision in the future.
+					return;
+				}
+
+				if (checkoutItemQueue.TryEnqueue(productBelt, out _)) {
+					nextCheckoutProductQueueTime = currentTime + CheckoutProductQueueInterval;
+				}
+			}
+		}
+
+
+		private void PerformCheckoutProductClick(ProductCheckoutSpawn productBelt, float currentTime) {
+			productBelt.isFinished = true;
+
+			if (productBelt.netId == 0) {
+				//Related to my use of productBelt.isFinished, in case I missed some case.
+				//	I ll still show errors so it doesnt get forgotten.
+				TimeLogger.Logger.LogTimeWarning($"Attempted to scan product " +
+					$"with netId 0. Skipping.", LogCategories.Other);
+				return;
+			}
+
+			productBelt.CmdAddProductValueToCheckout();
+
+			nextCheckoutProductPickTime = currentTime + CheckoutProductPickInterval;
+		}
+
+	}
+
+}

--- a/SMT_QoLity/SuperMarket/Patches/Misc/ExpandProductOrderClickArea.cs
+++ b/SMT_QoLity/SuperMarket/Patches/Misc/ExpandProductOrderClickArea.cs
@@ -1,0 +1,89 @@
+﻿using Damntry.Utils.Logging;
+using Damntry.UtilsBepInEx.HarmonyPatching.AutoPatching.BaseClasses.Inheritable;
+using SuperQoLity.SuperMarket.ModUtils;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace SuperQoLity.SuperMarket.Patches.Misc {
+
+	/// <summary>
+	/// Expands the clickable area of the blackboard product order button, so you can click anywhere in it.
+	/// </summary>
+	public class ExpandProductOrderClickArea : FullyAutoPatchedInstance {
+
+		public override bool IsAutoPatchEnabled => ModConfig.Instance.EnableMiscPatches.Value;
+
+		public override string ErrorMessageOnAutoPatchFail { get; protected set; } = 
+			$"{MyPluginInfo.PLUGIN_NAME} - Hold click to scan checkout products patch failed. Disabled.";
+
+
+		public override void OnPatchFinishedVirtual(bool IsPatchActive) {
+			if (IsPatchActive) {
+				ManageState();
+
+				ModConfig.Instance.EnableExpandedProdOrderClickArea.SettingChanged += (_, _) => ManageState();
+			}
+		}
+
+		
+		private void ManageState() {
+			if (ModConfig.Instance.EnableExpandedProdOrderClickArea.Value) {
+				WorldState.OnFPControllerStarted += ExpandOrderClickableArea;
+
+				if (WorldState.IsGameWorldAtOrAfter(GameWorldEvent.FPControllerStarted) && 
+						IsOrderUiPrefabLoaded(out ManagerBlackboard managerBlackboard)) {
+					ExpandOrderClickableArea(managerBlackboard);
+				}
+			} else {
+				WorldState.OnFPControllerStarted -= ExpandOrderClickableArea;
+
+				if (WorldState.IsGameWorldAtOrAfter(GameWorldEvent.FPControllerStarted) && 
+						IsOrderUiPrefabLoaded(out ManagerBlackboard managerBlackboard)) {
+					RestoreOrderClickableArea(managerBlackboard);
+				}
+			}
+		}
+
+		private void ExpandOrderClickableArea() {
+			if (!IsOrderUiPrefabLoaded(out ManagerBlackboard managerBlackboard)) {
+				TimeLogger.Logger.LogTimeError($"{nameof(ManagerBlackboard)}." +
+					$"{nameof(ManagerBlackboard.UIShopItemPrefab)} should be instanced " +
+					$"by now but its not.", LogCategories.UI);
+				return;
+			}
+
+			ExpandOrderClickableArea(managerBlackboard);
+		}
+
+		private void ExpandOrderClickableArea(ManagerBlackboard managerBlackboard) {
+			SetButtonClickableArea(managerBlackboard, new Vector4(-175, -5, -3, -50));
+
+			//Make the icons showing where the product shelf goes on non
+			//	interactable, otherwise the button wont work on top of them.
+			GameObject prodShelfIcon = managerBlackboard.UIShopItemPrefab.transform.Find("ContainerTypeBCK").gameObject;
+			prodShelfIcon.GetComponent<Image>().raycastTarget = false;
+			prodShelfIcon.transform.Find("ContainerImage").GetComponent<Image>().raycastTarget = false;
+		}
+
+		private void RestoreOrderClickableArea(ManagerBlackboard managerBlackboard) {
+			SetButtonClickableArea(managerBlackboard, Vector4.zero);
+		}
+
+		private void SetButtonClickableArea(ManagerBlackboard managerBlackboard, Vector4 padding) {
+			managerBlackboard.UIShopItemPrefab.transform.Find("AddButton")
+				.GetComponent<Image>()
+				//Any other way is better than doing this. And yet here we are.
+				.raycastPadding = padding;
+		}
+
+		private bool IsOrderUiPrefabLoaded(out ManagerBlackboard managerBlackboard) {
+			managerBlackboard = null;
+
+			return GameData.Instance != null 
+				&& GameData.Instance.TryGetComponent<ManagerBlackboard>(out managerBlackboard) 
+				&& managerBlackboard.UIShopItemPrefab != null;
+		}
+
+	}
+
+}

--- a/SMT_QoLity/SuperMarket/Patches/Misc/PricingGunFixPatch.cs
+++ b/SMT_QoLity/SuperMarket/Patches/Misc/PricingGunFixPatch.cs
@@ -21,7 +21,6 @@ namespace SuperQoLity.SuperMarket.Patches.Misc {
 		public override string ErrorMessageOnAutoPatchFail { get; protected set; } = $"{MyPluginInfo.PLUGIN_NAME} - Pricing Gun price patch failed. Disabled.";
 
 
-		[HarmonyDebug]
 		[HarmonyPatch(typeof(NPC_Manager), nameof(NPC_Manager.CustomerNPCControl))]
 		[HarmonyTranspiler]
 		public static IEnumerable<CodeInstruction> CustomerNPCControlTranspiler(IEnumerable<CodeInstruction> instructions, ILGenerator generator) {

--- a/SMT_QoLity/SuperMarket/Patches/Misc/SharedSavePatch.cs
+++ b/SMT_QoLity/SuperMarket/Patches/Misc/SharedSavePatch.cs
@@ -1,0 +1,197 @@
+﻿using System.Globalization;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Damntry.Utils.Logging;
+using Damntry.UtilsBepInEx.HarmonyPatching.AutoPatching.BaseClasses.Inheritable;
+using Damntry.UtilsUnity.Components;
+using HutongGames.PlayMaker;
+using Mirror;
+using UnityEngine;
+
+namespace SuperQoLity.SuperMarket.Patches.Misc {
+
+	public class SharedSavePatch : FullyAutoPatchedInstance {
+
+		public override bool IsAutoPatchEnabled => Plugin.IsSolutionInDebugMode;
+
+		public override string ErrorMessageOnAutoPatchFail { get; protected set; } = $"{MyPluginInfo.PLUGIN_NAME} - TestAndDebugPatch FAILED. Disabled";
+
+		public override void OnPatchFinishedVirtual(bool IsPatchActive) {
+			if (IsPatchActive) {
+				KeyPressDetection.AddHotkey(KeyCode.Less, 1000, () => { SaveAsClientX(); });
+			}
+		}
+
+
+		public static async void SaveAsClientX() {
+			//Based on BetterSMT and GameData.WaitUntilNewDay()
+			LOG.TEMPWARNING("Save started");
+
+			if (NetworkManager.singleton != null) {
+				TimeLogger.Logger.LogTimeWarning("You can only save in a loaded world.", LogCategories.Other);
+			}
+
+			NetworkSpawner nSpawnerComponent = GameData.Instance.GetComponent<NetworkSpawner>();
+			if (nSpawnerComponent.isSaving) {
+				TimeLogger.Logger.LogTimeWarning("Saving is already in progress.", LogCategories.Other);
+				return;
+			}
+
+			if (NetworkManager.singleton.mode == NetworkManagerMode.ClientOnly) {
+				//TODO 0 - Once tests are done, move all logic in here
+			}
+
+			string loadedSaveFileName = FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value;
+			string newSaveFileName = "StoreFile12.es3";
+
+			//TODO 0 - Should probably be doing this? BetterSMT does it twice for some reason.
+			//GameData.Instance.DoDaySaveBackup();
+
+			LOG.TEMPWARNING($"CurrentFilename: {loadedSaveFileName} - " +
+				$"City save name (host only) {GetCityName(loadedSaveFileName)}");
+
+			FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value = newSaveFileName;
+
+			await SavePersistentValues();
+
+			await SavePropsCoroutine();
+			//IEnumerator saveProps = save.gameDataOBJ.GetComponent<NetworkSpawner>().SavePropsCoroutine();
+			//while (saveProps.MoveNext());
+
+			//For safety more than anything else, since this only gets executed in the client.
+			FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value = loadedSaveFileName;
+
+			//TODO 0 - Notify the user of save finished.
+		}
+
+		private static string GetCityName(string loadedSaveFileName) {
+			string currentSaveFile = Path.Combine(Application.persistentDataPath, loadedSaveFileName);
+			ES3Settings settings = new(ES3.EncryptionType.AES, "g#asojrtg@omos)^yq");
+			ES3File file = new(currentSaveFile, settings, false);
+			return file.Load<string>("StoreName", null);
+
+			/*
+			ES3Settings settings = new ES3Settings(ES3.EncryptionType.AES, "g#asojrtg@omos)^yq");
+			ES3.CacheFile(currentSaveFile, settings);
+			ES3Settings settings2 = new ES3Settings(currentSaveFile, ES3.Location.Cache);
+			if (ES3.KeyExists("StoreName", settings)) {
+				ES3.Save("StoreName", ES3.Load<string>("StoreName", settings), settings);
+			} else {
+				LOG.TEMPFATAL($"Save slot city name not found.");
+			}
+			
+			string newSaveFilePath = Path.Combine(Application.persistentDataPath, newSaveFileName);
+			ES3.CacheFile(newSaveFilePath, settings);
+			ES3.StoreCachedFile(newSaveFilePath, settings);
+			*/
+		}
+
+		private static async Task SavePersistentValues() {
+			LOG.TEMPDEBUG("1. " + FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value);
+
+			PlayMakerFSM fsm = GameData.Instance.SaveOBJ.GetComponent<PlayMakerFSM>();
+			fsm.FsmVariables.GetFsmBool("IsSaving").Value = true;
+			LOG.TEMPDEBUG("2. " + FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value);
+			fsm.SendEvent("Send_Data");
+			LOG.TEMPDEBUG("3. " + FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value);
+			while (fsm.FsmVariables.GetFsmBool("IsSaving").Value) {
+				LOG.TEMPDEBUG("4. " + FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value);
+				await Task.Delay(10);
+				LOG.TEMPDEBUG("5. " + FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value);
+			}
+
+			/*
+			SaveBehaviour save = new() { gameDataOBJ = GameObject.Find("GameDataManager") };
+			save.SavePersistentValues();
+			netSpawner = save.gameDataOBJ.GetComponent<NetworkSpawner>();
+			*/
+		}
+
+		public static async Task SavePropsCoroutine() {
+			NetworkSpawner instance = GameObject.Find("GameDataManager").GetComponent<NetworkSpawner>();
+
+			instance.isSaving = true;
+
+			GameCanvas.Instance.transform.Find("SavingContainer").gameObject.SetActive(value: true);
+			await Task.Delay(500);
+			int counter = 0;
+			string value = FsmVariables.GlobalVariables.GetFsmString("CurrentFilename").Value;
+			string filepath = Application.persistentDataPath + "/" + value;
+			LOG.TEMPWARNING($"We will save props in file \"{value}\"");
+			ES3Settings cacheSettings = new ES3Settings(ES3.EncryptionType.AES, "g#asojrtg@omos)^yq");
+			ES3.CacheFile(filepath, cacheSettings);
+			ES3Settings settings = new ES3Settings(filepath, ES3.Location.Cache);
+			CultureInfo cultureInfo = new CultureInfo(Thread.CurrentThread.CurrentCulture.Name);
+			if (cultureInfo.NumberFormat.NumberDecimalSeparator != ",") {
+				cultureInfo.NumberFormat.NumberDecimalSeparator = ",";
+				Thread.CurrentThread.CurrentCulture = cultureInfo;
+			}
+
+			for (int i = 0; i < 4; i++) {
+				GameObject gameObject = instance.levelPropsOBJ.transform.GetChild(i).gameObject;
+				if (gameObject.transform.childCount != 0) {
+					LOG.TEMPWARNING($"Saving {gameObject.transform.childCount} levelPropsOBJ objects for index {i}.");
+					for (int j = 0; j < gameObject.transform.childCount; j++) {
+						GameObject gameObject2 = gameObject.transform.GetChild(j).gameObject;
+						string value2 = i + "|" + gameObject2.GetComponent<Data_Container>().containerID + "|" + gameObject2.transform.position.x + "|" + gameObject2.transform.position.y + "|" + gameObject2.transform.position.z + "|" + gameObject2.transform.rotation.eulerAngles.y;
+						ES3.Save("propdata" + counter, value2, filepath, settings);
+						string key = "propinfoproduct" + counter;
+						int[] productInfoArray = gameObject2.GetComponent<Data_Container>().productInfoArray;
+						ES3.Save(key, productInfoArray, filepath, settings);
+						counter++;
+					}
+				}
+			}
+
+			for (int k = counter; (float)k < float.PositiveInfinity; k++) {
+				string key2 = "propdata" + counter;
+				if (!ES3.KeyExists(key2, filepath, settings)) {
+					break;
+				}
+
+				ES3.DeleteKey(key2, filepath, settings);
+			}
+
+			counter = 0;
+			int num = 0;
+			GameObject parentOBJ2 = instance.levelPropsOBJ.transform.GetChild(7).gameObject;
+			for (int l = 0; (float)l < float.PositiveInfinity; l++) {
+				string key3 = "decopropdata" + num;
+				if (!ES3.KeyExists(key3, filepath, settings)) {
+					break;
+				}
+
+				ES3.DeleteKey(key3, filepath, settings);
+				num++;
+			}
+
+			LOG.TEMPWARNING($"Saving {parentOBJ2.transform.childCount} decorative objects.");
+			for (int m = 0; m < parentOBJ2.transform.childCount; m++) {
+				GameObject gameObject3 = parentOBJ2.transform.GetChild(m).gameObject;
+				string value3 = "7|" + gameObject3.GetComponent<BuildableInfo>().decorationID + "|" + gameObject3.transform.position.x + "|" + gameObject3.transform.position.y + "|" + gameObject3.transform.position.z + "|" + gameObject3.transform.rotation.eulerAngles.y;
+				ES3.Save("decopropdata" + counter, value3, filepath, settings);
+				if (gameObject3.GetComponent<BuildableInfo>().decorationID == 4) {
+					string key4 = "decopropdataextra" + counter;
+					string value4 = gameObject3.GetComponent<DecorationExtraData>().intValue + "|" + gameObject3.GetComponent<DecorationExtraData>().stringValue;
+					ES3.Save(key4, value4, filepath, settings);
+				}
+
+				if ((bool)gameObject3.GetComponent<PaintableDecoration>()) {
+					string key5 = "decopaintabledata" + counter;
+					string value5 = gameObject3.GetComponent<PaintableDecoration>().mainValue + "|" + gameObject3.GetComponent<PaintableDecoration>().secondaryValue;
+					ES3.Save(key5, value5, filepath, settings);
+				}
+
+				counter++;
+			}
+
+			ES3.StoreCachedFile(filepath, cacheSettings);
+			await Task.Delay(20);
+			GameCanvas.Instance.transform.Find("SavingContainer").gameObject.SetActive(value: false);
+			LOG.TEMPWARNING($"Prop saving finished.");
+			instance.isSaving = false;
+		}
+
+	}
+}

--- a/SMT_QoLity/SuperMarket/Patches/PerformanceCachingPatch.cs
+++ b/SMT_QoLity/SuperMarket/Patches/PerformanceCachingPatch.cs
@@ -53,6 +53,11 @@ namespace SuperQoLity.SuperMarket.Patches {
 					//The Data_Container belongs to a product shelf object. Calculate its capacity for each product.
 					foreach (GameObject prodPrefab in ProductListing.Instance.productPrefabs) {
 
+						if (prodPrefab == null) {
+							//Support for mod "Custom Products" that resizes the array to a
+							//	fixed 9999 elements, leaving empty ones.
+							continue;
+						}
 						int productId = prodPrefab.GetComponent<Data_Product>().productID;
 						int maxProductsPerRow = GetMaxProductsPerRow(dataContainer, productId);
 						maxProductsPerRowCache.Add((dataContainer.containerClass, dataContainer.containerID, productId), maxProductsPerRow);

--- a/SMT_QoLity/SuperMarket/WorldState.cs
+++ b/SMT_QoLity/SuperMarket/WorldState.cs
@@ -11,53 +11,90 @@ namespace SuperQoLity.SuperMarket {
 	}
 
 	public enum GameWorldEvent {
-		LoadingWorld,
-		CanvasLoaded,
-		WorldStarted,
-		QuitOrMenu
+		QuitOrMenu = 0,
+		LoadingWorld = 1,
+		CanvasLoaded = 2,
+		FPControllerStarted = 3,
+		WorldStarted = 4,
 	}
 
 	public static class WorldState {
 
 		public static event Action<GameWorldEvent> OnGameWorldChange;
 
+		public static event Action OnQuitOrMenu;
 		public static event Action OnLoadingWorld;
 		public static event Action OnCanvasLoaded;
+		public static event Action OnFPControllerStarted;
 		public static event Action OnWorldStarted;
-		public static event Action OnQuitOrMenu;
 
 
-		public static bool IsGameWorldLoadingOrStarted =>
-			GameWorldState == GameWorldEvent.LoadingWorld || GameWorldState == GameWorldEvent.WorldStarted;
-
-		public static bool IsGameWorldStarted => 
-			GameWorldState == GameWorldEvent.WorldStarted;
-
-
-		public static GameWorldEvent GameWorldState { get; private set; } = GameWorldEvent.QuitOrMenu;
+		public static GameWorldEvent CurrentGameWorldState { get; private set; } = GameWorldEvent.QuitOrMenu;
 
 		public static GameOnlineMode CurrenOnlineMode { get; set; } = GameOnlineMode.None;
 
 
+		public static bool IsGameWorldStarted =>
+			CurrentGameWorldState == GameWorldEvent.WorldStarted;
+
+		/// <summary>
+		/// Returns true if the world state is at, or after, the state passed through parameter.
+		/// <see cref="GameWorldEvent"/> for the order of events
+		/// </summary>
+		public static bool IsGameWorldAtOrAfter(GameWorldEvent worldState) =>
+			(int)CurrentGameWorldState >= (int)worldState;
+
+
 		public static void SetGameWorldState(GameWorldEvent state) {
-			TimeLogger.Logger.LogTimeDebugFunc(() => $"World state change from {GameWorldState} to {state}", LogCategories.Loading);
-			GameWorldState = state;
+			TimeLogger.Logger.LogTimeDebugFunc(() => $"World state change from {CurrentGameWorldState} to {state}", LogCategories.Loading);
+			CurrentGameWorldState = state;
 
 			//Trigger the world state change event
-			EventMethods.TryTriggerEvents(OnGameWorldChange, GameWorldState);
+			EventMethods.TryTriggerEvents(OnGameWorldChange, state);
 
 			//Trigger the specific event
 			EventMethods.TryTriggerEvents(
-				state switch {
-					GameWorldEvent.LoadingWorld => OnLoadingWorld,
-					GameWorldEvent.CanvasLoaded => OnCanvasLoaded,
-					GameWorldEvent.WorldStarted => OnWorldStarted,
-					GameWorldEvent.QuitOrMenu => OnQuitOrMenu,
-					_ => null
-				}
+				GetSubscribersForWorldState(state)
 			);
-			
 		}
+
+		public static void SubscribeToWorldStateEvent(GameWorldEvent state, Action actionOnEvent) {
+			switch (state) {
+				case GameWorldEvent.QuitOrMenu:
+					OnQuitOrMenu += actionOnEvent;
+					break;
+				case GameWorldEvent.LoadingWorld:
+					OnLoadingWorld += actionOnEvent;
+					break;
+				case GameWorldEvent.CanvasLoaded:
+					OnCanvasLoaded += actionOnEvent;
+					break;
+				case GameWorldEvent.FPControllerStarted:
+					OnFPControllerStarted += actionOnEvent;
+					break;
+				case GameWorldEvent.WorldStarted:
+					OnWorldStarted += actionOnEvent;
+					break;
+			}
+		}
+
+
+		/// <summary>
+		/// Gets an Action with all existing subscribers for the related state event.
+		/// </summary>
+		/// <param name="state">The state from which its related action event will be returned.</param>
+		/// <remarks>The return Action is only meant to be used to access current event subscriptions.
+		/// It does not represent the original event, so it cant be subscribed to.
+		/// For subscriptions use <see cref="SubscribeToWorldStateEvent"/> instead</remarks>
+		public static Action GetSubscribersForWorldState(GameWorldEvent state) =>
+			state switch {
+				GameWorldEvent.QuitOrMenu => OnQuitOrMenu,
+				GameWorldEvent.LoadingWorld => OnLoadingWorld,
+				GameWorldEvent.CanvasLoaded => OnCanvasLoaded,
+				GameWorldEvent.FPControllerStarted => OnFPControllerStarted,
+				GameWorldEvent.WorldStarted => OnWorldStarted,
+				_ => null
+			};
 
 	}
 }

--- a/SMT_QoLity/SuperQoLity.csproj
+++ b/SMT_QoLity/SuperQoLity.csproj
@@ -58,6 +58,12 @@
     <Reference Include="PlayMaker">
       <HintPath>lib\PlayMaker.dll</HintPath>
     </Reference>
+    <Reference Include="Rewired_Core">
+      <HintPath>lib\Rewired_Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Rewired_Windows">
+      <HintPath>lib\Rewired_Windows.dll</HintPath>
+    </Reference>
     <Reference Include="UniTask">
       <HintPath>lib\UniTask.dll</HintPath>
     </Reference>


### PR DESCRIPTION
…oducts, instead of clicking them individually.

- New patch to expand the clickable area of the product order button in the blackboard.
- First incomplete iteration of the Shared saving feature. Partially working.
- New ClickBehaviour component for generic methods that need to be checked on an Update
- Added support for "Custom Products" mod to avoid an exception when loading the game.
- Small employee AI change to match last base game update.
- New SMTGameObjectManager to centralize access to game objects, GameObject creations, and component attachment.
- Added a new way to check if we are at, or after, the specified world state event.
- Added the new world state event "FPControllerStarted". It contains many commonly used Behaviours.
- Fix to make the notification check interval much shorter and independent of the notification show time.
- Removed transpiler debug from PricingGunFixPatch.
- Removed duplicated quit to menu debug log.